### PR TITLE
Remove spurious "@" from install rule

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,17 +15,17 @@ cp2bin:		$(abs_top_builddir)/src/reflex
 
 install-data-hook:
 		@echo " ______________________________________________________ "; \
-		@echo "|                                                      |"; \
-		@echo "| You have successfully built and installed reflex.    |"; \
-		@echo "|                                                      |"; \
-		@echo "| You can use the reflex command to generate scanners. |"; \
-		@echo "| Link your generated scanner with -lreflex.           |"; \
-		@echo "|                                                      |"; \
-		@echo "| Thanks for using reflex.                             |"; \
-		@echo "|                                                      |"; \
-		@echo "|             https://github.com/Genivia/RE-flex       |"; \
-		@echo "|             https://sourceforge.net/projects/re-flex |"; \
-		@echo "|______________________________________________________|";
+		 echo "|                                                      |"; \
+		 echo "| You have successfully built and installed reflex.    |"; \
+		 echo "|                                                      |"; \
+		 echo "| You can use the reflex command to generate scanners. |"; \
+		 echo "| Link your generated scanner with -lreflex.           |"; \
+		 echo "|                                                      |"; \
+		 echo "| Thanks for using reflex.                             |"; \
+		 echo "|                                                      |"; \
+		 echo "|             https://github.com/Genivia/RE-flex       |"; \
+		 echo "|             https://sourceforge.net/projects/re-flex |"; \
+		 echo "|______________________________________________________|";
 
 .PHONY:		test
 


### PR DESCRIPTION
The makefile.am install rule tried to output a banner
on installation. In order to avoid echoing the "echo"
command, it was prefixed with "@", but this was done
for _every_ line. The trailing escape ("\\") meant that
as far as Make was concerned, it was a single line with
lots of "@" symbols, all of which were passed to the
shell, which then errored out.

It's harder to explain than to fix!

(Makefile.in has the same problem, but is autogenerated).