### PR TITLE
MinGW Fixes

### DIFF
--- a/include/reflex/convert.h
+++ b/include/reflex/convert.h
@@ -67,7 +67,7 @@ namespace convert_flag {
   const convert_flag_type multiline = 0x0040; ///< regex with multiline anchors `^` and `$`, same as `(?m)`
   const convert_flag_type dotall    = 0x0080; ///< convert `.` (dot) to match all, same as `(?s)`
   const convert_flag_type freespace = 0x0100; ///< convert regex by removing spacing, same as `(?x)`
-};
+}
 
 /// @brief Returns the converted regex string given a regex library signature and conversion flags, throws regex_error.
 ///

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -43,7 +43,7 @@ FILE *REFLEX_DBGFD_ = NULL;
 
 extern "C" {
 
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
 
 #include <windows.h>
 void REFLEX_DBGOUT_(const char *log, const char *file, int line)


### PR DESCRIPTION
Addressing issue #38 

Also removed an extra semicolon in include/reflex/convert.h:69 either `-Wall` or `-pendatic` keeps nagging at me about