### PR TITLE
<<EOF>> is not a real regex, do not adjust it

### DIFF
--- a/src/reflex.cpp
+++ b/src/reflex.cpp
@@ -1018,6 +1018,10 @@ std::string Reflex::get_regex(size_t& pos)
       nsp = pos;
   }
   regex.append(line.substr(loc, pos - loc));
+
+  if (regex == "<<EOF>>")
+    return regex;
+
   reflex::convert_flag_type flags = reflex::convert_flag::lex;
   if (!options["case_insensitive"].empty())
     flags |= reflex::convert_flag::anycase;


### PR DESCRIPTION
Definitely don't turn it into <<[Ee][Oo][Ff]>> in case-insensitive mode.

Fixes: #62