### PR TITLE
Fix build errors with MSVC++

### DIFF
--- a/include/reflex/bits.h
+++ b/include/reflex/bits.h
@@ -41,6 +41,7 @@
 
 #if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)
 namespace reflex {
+typedef unsigned __int8  uint8_t;
 typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;

--- a/include/reflex/matcher.h
+++ b/include/reflex/matcher.h
@@ -139,19 +139,19 @@ class Matcher : public PatternMatcher<reflex::Pattern> {
   {
     if (n == 0)
       return std::pair<const char*,size_t>(txt_, len_);
-    return std::pair<const char*,size_t>(NULL, 0);
+    return std::pair<const char*,size_t>(reinterpret_cast<const char*>(NULL), 0);
   }
   /// Returns the group capture identifier containing the group capture index >0 and name (or NULL) of a named group capture, or (1,NULL) by default
   virtual std::pair<size_t,const char*> group_id()
     /// @returns a pair of size_t and string
   {
-    return std::pair<size_t,const char*>(accept(), NULL);
+    return std::pair<size_t,const char*>(accept(), reinterpret_cast<const char*>(NULL));
   }
   /// Returns the next group capture identifier containing the group capture index >0 and name (or NULL) of a named group capture, or (0,NULL) when no more groups matched
   virtual std::pair<size_t,const char*> group_next_id()
     /// @returns (0,NULL)
   {
-    return std::pair<size_t,const char*>(0, NULL);
+    return std::pair<size_t,const char*>(0, reinterpret_cast<const char*>(NULL));
   }
   /// Returns the position of the last indent stop.
   size_t last_stop()

--- a/lib/pattern.cpp
+++ b/lib/pattern.cpp
@@ -2065,7 +2065,7 @@ void Pattern::encode_dfa(DFA::State *start)
     // add final dead state (HALT opcode) only when needed, i.e. skip dead state if all chars 0-255 are already covered
     if (hi <= 0xFF)
     {
-      state->edges[hi] = std::pair<Char,DFA::State*>(0xFF, NULL);
+      state->edges[hi] = std::pair<Char,DFA::State*>(0xFF, reinterpret_cast<DFA::State*>(NULL));
       ++nop_;
     }
 #else
@@ -2088,7 +2088,7 @@ void Pattern::encode_dfa(DFA::State *start)
     // add final dead state (HALT opcode) only when needed, i.e. skip dead state if all chars 0-255 are already covered
     if (!covered)
     {
-      state->edges[lo] = std::pair<Char,DFA::State*>(0x00, NULL);
+      state->edges[lo] = std::pair<Char,DFA::State*>(0x00, reinterpret_cast<DFA::State*>(NULL));
       ++nop_;
     }
 #endif


### PR DESCRIPTION
There are two problems.
It happens when someone build csv.l in the examples with old MSVC++, for example.

First, the following error.
```
reflex/pattern.h(66) : error C2146: syntax error : missing ';' before identifier 'Pred'
```
```cxx
   class Pattern {
     friend class Matcher;      ///< permit access by the reflex::Matcher engine
     friend class FuzzyMatcher; ///< permit access by the reflex::FuzzyMatcher engine
    public:
->   typedef uint8_t  Pred;   ///< predict match bits
     typedef uint16_t Hash;   ///< hash value type, max value is Const::HASH
     typedef uint32_t Index;  ///< index into opcodes array Pattern::opc_ and subpattern indexing
     typedef uint32_t Accept; ///< group capture index
```

This happens at least in MSVC++ 2010, 2012, and 2013, because there is no `uint8_t` definition in `reflex/bits.h`.
```cxx
#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)
namespace reflex {
typedef unsigned __int16 uint16_t;
typedef unsigned __int32 uint32_t;
typedef unsigned __int64 uint64_t;
}
#else
# include <stdint.h>
#endif
```

Added the definition of `uint8_t` to `reflex/bits.h` and solved it.

But, correcting this issue still gives the following error with MSVC++ 2010:
```
c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\INCLUDE\utility(163) : error C2440: 'initializing': cannot convert from 'int' to 'const char *'
```

This happens because it is trying to initialize pointer with NULL (aka integral type 0) like below.
```cxx
void Pattern::encode_dfa(DFA::State *start)
{
  nop_ = 0;
  for (DFA::State *state = start; state; state = state->next)
  {
      :
    for (DFA::State::Edges::const_reverse_iterator i = state->edges.rbegin(); i != state->edges.rend(); ++i)
    {
      :
    // add dead state only when needed, i.e. skip dead state only if all input is covered
    if (!covered)
    {
->    state->edges[lo] = std::pair<Char,DFA::State*>(0x00, NULL);
      ++nop_;
    }
```

To solve this problem, I have provided `reflex/defines.h`, then defined the `YY_NULLPTR` macro like Bison, and replaced `NULL` where it might have an impact on execution.
Also, there is no support for C language, but it should be no problem because RE/flex is the based on C++.
In addition, to get the expected value of `__cplusplus` in MSVC++, it is necessary more work, that is to specify the compile option, so `_MSC_VER` is used.
`1600 <=_MSC_VER` means MSVC++2010 or later which has `nullptr`.
```cxx
#ifndef YY_NULLPTR
# if 201103L <= __cplusplus || defined (_MSC_VER) && 1600 <=_MSC_VER
#  define YY_NULLPTR nullptr
# else
#  define YY_NULLPTR 0
# endif
#endif // YY_NULLPTR
```