### PR TITLE
Fix unallowed reinterpret_cast

### DIFF
--- a/include/reflex/matcher.h
+++ b/include/reflex/matcher.h
@@ -139,19 +139,19 @@ class Matcher : public PatternMatcher<reflex::Pattern> {
   {
     if (n == 0)
       return std::pair<const char*,size_t>(txt_, len_);
-    return std::pair<const char*,size_t>(reinterpret_cast<const char*>(NULL), 0);
+    return std::pair<const char*,size_t>(nullptr, 0);
   }
   /// Returns the group capture identifier containing the group capture index >0 and name (or NULL) of a named group capture, or (1,NULL) by default
   virtual std::pair<size_t,const char*> group_id()
     /// @returns a pair of size_t and string
   {
-    return std::pair<size_t,const char*>(accept(), reinterpret_cast<const char*>(NULL));
+    return std::pair<size_t,const char*>(accept(), nullptr);
   }
   /// Returns the next group capture identifier containing the group capture index >0 and name (or NULL) of a named group capture, or (0,NULL) when no more groups matched
   virtual std::pair<size_t,const char*> group_next_id()
     /// @returns (0,NULL)
   {
-    return std::pair<size_t,const char*>(0, reinterpret_cast<const char*>(NULL));
+    return std::pair<size_t,const char*>(0, nullptr);
   }
   /// Returns the position of the last indent stop.
   size_t last_stop()

--- a/lib/pattern.cpp
+++ b/lib/pattern.cpp
@@ -2065,7 +2065,7 @@ void Pattern::encode_dfa(DFA::State *start)
     // add final dead state (HALT opcode) only when needed, i.e. skip dead state if all chars 0-255 are already covered
     if (hi <= 0xFF)
     {
-      state->edges[hi] = std::pair<Char,DFA::State*>(0xFF, reinterpret_cast<DFA::State*>(NULL));
+      state->edges[hi] = std::pair<Char,DFA::State*>(0xFF, nullptr);
       ++nop_;
     }
 #else


### PR DESCRIPTION
See note at ¶5.2.10, bullet 9, of the n3797 C++ draft:

"A null pointer constant of type std::nullptr_t cannot be converted to a
pointer type, and a null pointer constant of integral type is not
necessarily converted to a null pointer value."

This addresses the following clang90 errors:

```
../include/reflex/matcher.h:142:42: error: reinterpret_cast from 'nullptr_t' to 'const char *' is not allowed
    return std::pair<const char*,size_t>(reinterpret_cast<const char*>(NULL), 0);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/reflex/matcher.h:148:52: error: reinterpret_cast from 'nullptr_t' to 'const char *' is not allowed
    return std::pair<size_t,const char*>(accept(), reinterpret_cast<const char*>(NULL));
                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/reflex/matcher.h:154:45: error: reinterpret_cast from 'nullptr_t' to 'const char *' is not allowed
    return std::pair<size_t,const char*>(0, reinterpret_cast<const char*>(NULL));
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pattern.cpp:2068:60: error: reinterpret_cast from 'nullptr_t' to 'DFA::State *' is not allowed
      state->edges[hi] = std::pair<Char,DFA::State*>(0xFF, reinterpret_cast<DFA::State*>(NULL));
                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```