### PR TITLE
Advise to use bash instead of sh while building

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ First clone the code:
 Then simply do a quick clean build, assuming your environment is pretty much
 standard:
 
-    $ sh clean.sh
-    $ sh build.sh
+    $ ./clean.sh
+    $ ./build.sh
 
 This compiles the **reflex** tool and installs it locally in `reflex/bin`.  For
 local use of RE/flex in your project, you can add this location to your `$PATH`
@@ -179,7 +179,7 @@ project are locally located in `include/reflex`.
 To install the man page, the header files in `/usr/local/include/reflex`, the
 library in `/usr/local/lib` and the `reflex` command in `/usr/local/bin`:
 
-    $ sudo sh allinstall.sh
+    $ sudo ./allinstall.sh
 
 ### Configure and make
 


### PR DESCRIPTION
Currently the build fails when using sh:

```
  % sh build.sh

  Building reflex...

  build.sh: 12: build.sh: Syntax error: Bad fd number
```

... but it passes when ran the way it's intended to (`./build.sh`).

The script already contains the correct shebang, so it's just the matter of using the correct shell.