### PR TITLE
Remove MinGW conditionals causing build failure

### DIFF
--- a/include/reflex/absmatcher.h
+++ b/include/reflex/absmatcher.h
@@ -299,7 +299,7 @@ class AbstractMatcher {
     if (own_)
     {
 #if defined(WITH_REALLOC)
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
       _aligned_free(static_cast<void*>(buf_));
 #else
       std::free(static_cast<void*>(buf_));
@@ -343,7 +343,7 @@ class AbstractMatcher {
     {
       max_ = 2 * Const::BLOCK;
 #if defined(WITH_REALLOC)
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
       buf_ = static_cast<char*>(_aligned_malloc(max_, 4096));
       if (buf_ == NULL)
         throw std::bad_alloc();
@@ -479,7 +479,7 @@ class AbstractMatcher {
       if (own_)
       {
 #if defined(WITH_REALLOC)
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
         _aligned_free(static_cast<void*>(buf_));
 #else
         std::free(static_cast<void*>(buf_));
@@ -1407,7 +1407,7 @@ class AbstractMatcher {
         max_ *= 2;
       DBGLOG("Expand buffer to %zu bytes", max_);
 #if defined(WITH_REALLOC)
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
       char *newbuf = static_cast<char*>(_aligned_realloc(static_cast<void*>(buf_), max_, 4096));
 #else
       char *newbuf = static_cast<char*>(std::realloc(static_cast<void*>(buf_), max_));
@@ -1457,7 +1457,7 @@ class AbstractMatcher {
         num_ += gap;
 #if defined(WITH_REALLOC)
         std::memmove(buf_, txt_, end_);
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
         char *newbuf = static_cast<char*>(_aligned_realloc(static_cast<void*>(buf_), max_, 4096));
 #else
         char *newbuf = static_cast<char*>(std::realloc(static_cast<void*>(buf_), max_));


### PR DESCRIPTION
The `_aligned_malloc` alternative caused a build failure, as `posix_memalign` is not implemented in MinGW.
As @genivia-inc mentioned in https://github.com/Genivia/RE-flex/issues/100?_pjax=%23js-repo-pjax-container#issuecomment-794106261, these should be removed:
> Basically, all !defined(__MINGW32__) && !defined(__MINGW64__) conditions should be removed in this file.

I have removed them and verified the build succeeds in MSYS2/MinGW.