### PR TITLE
Fix segfault for Pattern::operator=()

### DIFF
--- a/include/reflex/pattern.h
+++ b/include/reflex/pattern.h
@@ -166,7 +166,8 @@ class Pattern {
   void clear()
   {
     rex_.clear();
-    delete[] opc_;
+    if (opc_ != NULL && nop_ > 0)
+      delete[] opc_;
     opc_ = NULL;
     nop_ = 0;
     fsm_ = NULL;

--- a/include/reflex/pattern.h
+++ b/include/reflex/pattern.h
@@ -166,8 +166,7 @@ class Pattern {
   void clear()
   {
     rex_.clear();
-    if (nop_ > 0 && opc_ != NULL)
-      delete[] opc_;
+    delete[] opc_;
     opc_ = NULL;
     nop_ = 0;
     fsm_ = NULL;
@@ -965,7 +964,7 @@ class Pattern {
   std::vector<bool>     acc_; ///< true if subpattern n is accepting (state is reachable)
   size_t                vno_; ///< number of finite state machine vertices |V|
   size_t                eno_; ///< number of finite state machine edges |E|
-  const Opcode         *opc_; ///< points to the opcode table
+  const Opcode         *opc_ = NULL; ///< points to the opcode table
   Index                 nop_; ///< number of opcodes generated
   FSM                   fsm_; ///< function pointer to FSM code
   size_t                len_; ///< prefix length of pre_[], less or equal to 255


### PR DESCRIPTION
I noticed while running RE-Flex with AddressSanitizer that `Pattern` suffers from a segfault when using `operator=` construction.

Example:
```C++
struct AClass {
    Pattern p;
    AClass() {
        p = Pattern(MY_REGEX);
    }
}
```

Output
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==9119==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x000000488b94 bp 0x000000000000 sp 0x7ffc4e3e0770 T0)
==9119==The signal is caused by a READ memory access.
==9119==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x488b94 in __asan::Allocator::Deallocate(void*, unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType) (/home/tumbar/git/neoast/cmake-build-asan/src/codegen/neoast-bootstrap+0x488b94)
    #1 0x534ad5 in operator delete[](void*) (/home/tumbar/git/neoast/cmake-build-asan/src/codegen/neoast-bootstrap+0x534ad5)
    #2 0x583be5 in reflex::Pattern::clear() /home/tumbar/git/neoast/third_party/reflex/include/reflex/pattern.h:169:5
    #3 0x5866bf in reflex::Pattern::operator=(reflex::Pattern const&) /home/tumbar/git/neoast/third_party/reflex/include/reflex/pattern.h:228:5
    #4 0x586599 in reflex::Pattern::Pattern(reflex::Pattern const&) /home/tumbar/git/neoast/third_party/reflex/include/reflex/pattern.h:158:5
```

The culprit is that `operator=` assumes the structure fields in `this` to be initialized even though they may not be:
https://github.com/Genivia/RE-flex/blob/ee9e5f9744edaed999f5d2ac35518943a144ec80/include/reflex/pattern.h#L168-L171

https://github.com/Genivia/RE-flex/blob/ee9e5f9744edaed999f5d2ac35518943a144ec80/include/reflex/pattern.h#L227-L230

This PR will fix this by setting a default initializer for this pointer.

Great software BTW!!