### PR TITLE
Cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ config.h
 config.status
 config.log
 stamp-h1
+
+# default cmake build directory
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,22 +31,24 @@ set(bin_sources
   src/reflex.cpp
 )
 
-set(headers
-  ${PROJECT_SOURCE_DIR}/include
-)
-
 list(TRANSFORM lib_sources PREPEND ${PROJECT_SOURCE_DIR}/)
 list(TRANSFORM bin_sources PREPEND ${PROJECT_SOURCE_DIR}/)
 
 add_library(libreflex SHARED "")
 target_sources(libreflex PRIVATE ${lib_sources})
-target_include_directories(libreflex PUBLIC ${headers})
+target_include_directories(libreflex PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 target_compile_definitions(libreflex PRIVATE ${simd_definitions})
 target_compile_options(libreflex PRIVATE ${simd_flags})
 
 add_library(libreflexStatic STATIC "")
 target_sources(libreflexStatic PRIVATE ${lib_sources})
-target_include_directories(libreflexStatic PUBLIC ${headers})
+target_include_directories(libreflexStatic PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 target_compile_definitions(libreflexStatic PRIVATE ${simd_definitions})
 target_compile_options(libreflexStatic PRIVATE ${simd_flags})
 
@@ -58,7 +60,6 @@ set_target_properties(libreflex
     PROPERTIES OUTPUT_NAME reflex
 )
 
-
 add_executable(reflex "")
 target_sources(reflex PRIVATE ${bin_sources})
 target_link_libraries(reflex PRIVATE libreflexStatic)
@@ -67,12 +68,16 @@ target_compile_options(reflex PRIVATE ${simd_flags})
 
 include(GNUInstallDirs)
 
-install(TARGETS reflex libreflex libreflexStatic
+install(TARGETS reflex libreflex libreflexStatic EXPORT reflex
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(DIRECTORY include/reflex
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/reflex
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h"
 )
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/cmake/reflex-config.cmake DESTINATION reflex/share/reflex)
+
+install(EXPORT reflex DESTINATION reflex/share/reflex)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(reflex CXX)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake;${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+
+set(CMAKE_CXX_STANDARD 11)
+
+# The following setups the simd_* variables
+include(SIMDTestAndSetup)
+
+set(lib_sources
+  lib/convert.cpp
+  lib/debug.cpp
+  lib/error.cpp
+  lib/input.cpp
+  lib/matcher.cpp
+  lib/pattern.cpp
+  lib/posix.cpp
+  lib/simd_avx2.cpp
+  lib/simd_avx512bw.cpp
+  lib/unicode.cpp
+  lib/utf8.cpp
+
+  unicode/block_scripts.cpp
+  unicode/language_scripts.cpp
+  unicode/letter_scripts.cpp
+)
+
+set(bin_sources
+  src/reflex.cpp
+)
+
+set(headers
+  ${CMAKE_CURRENT_LIST_DIR}/include
+)
+
+list(TRANSFORM lib_sources PREPEND ${CMAKE_CURRENT_LIST_DIR}/)
+list(TRANSFORM bin_sources PREPEND ${CMAKE_CURRENT_LIST_DIR}/)
+
+add_library(libreflex SHARED "")
+target_sources(libreflex PRIVATE ${lib_sources})
+target_include_directories(libreflex PUBLIC ${headers})
+target_compile_definitions(libreflex PRIVATE ${simd_definitions})
+target_compile_options(libreflex PRIVATE ${simd_flags})
+
+add_library(libreflexStatic STATIC "")
+target_sources(libreflexStatic PRIVATE ${lib_sources})
+target_include_directories(libreflexStatic PUBLIC ${headers})
+target_compile_definitions(libreflexStatic PRIVATE ${simd_definitions})
+target_compile_options(libreflexStatic PRIVATE ${simd_flags})
+
+# Renaming static lib output to match the name (without the extention) of the shared library
+set_target_properties(libreflexStatic PROPERTIES OUTPUT_NAME libreflex)
+
+add_executable(reflex "")
+target_sources(reflex PRIVATE ${bin_sources})
+target_link_libraries(reflex PRIVATE libreflexStatic)
+target_compile_definitions(reflex PRIVATE ${simd_definitions})
+target_compile_options(reflex PRIVATE ${simd_flags})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,16 @@ cmake_minimum_required(VERSION 3.15)
 
 project(reflex CXX)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake;${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 set(CMAKE_CXX_STANDARD 11)
 
 # The following setups the simd_* variables
 include(SIMDTestAndSetup)
+
+#
+# Defining source variables
+#
 
 set(lib_sources
   lib/convert.cpp
@@ -34,50 +38,75 @@ set(bin_sources
 list(TRANSFORM lib_sources PREPEND ${PROJECT_SOURCE_DIR}/)
 list(TRANSFORM bin_sources PREPEND ${PROJECT_SOURCE_DIR}/)
 
-add_library(libreflex SHARED "")
-target_sources(libreflex PRIVATE ${lib_sources})
-target_include_directories(libreflex PUBLIC
+#
+# Defining targets section
+#
+
+add_library(ReflexLib SHARED "")
+target_sources(ReflexLib PRIVATE ${lib_sources})
+target_include_directories(ReflexLib PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_definitions(libreflex PRIVATE ${simd_definitions})
-target_compile_options(libreflex PRIVATE ${simd_flags})
+target_compile_definitions(ReflexLib PRIVATE ${simd_definitions})
+target_compile_options(ReflexLib PRIVATE ${simd_flags})
 
-add_library(libreflexStatic STATIC "")
-target_sources(libreflexStatic PRIVATE ${lib_sources})
-target_include_directories(libreflexStatic PUBLIC
+add_library(ReflexLibStatic STATIC "")
+target_sources(ReflexLibStatic PRIVATE ${lib_sources})
+target_include_directories(ReflexLibStatic PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_definitions(libreflexStatic PRIVATE ${simd_definitions})
-target_compile_options(libreflexStatic PRIVATE ${simd_flags})
+target_compile_definitions(ReflexLibStatic PRIVATE ${simd_definitions})
+target_compile_options(ReflexLibStatic PRIVATE ${simd_flags})
 
-# Renaming static lib output to match the name (without the extention) of the shared library
-set_target_properties(libreflexStatic
-    PROPERTIES OUTPUT_NAME reflex
-)
-set_target_properties(libreflex
-    PROPERTIES OUTPUT_NAME reflex
+add_executable(Reflex "")
+target_sources(Reflex PRIVATE ${bin_sources})
+target_link_libraries(Reflex PRIVATE ReflexLibStatic)
+target_compile_definitions(Reflex PRIVATE ${simd_definitions})
+target_compile_options(Reflex PRIVATE ${simd_flags})
+
+# Don't user target name as filename instead use lowercase name for backwards compatibility
+set_target_properties(ReflexLibStatic ReflexLib Reflex
+  PROPERTIES OUTPUT_NAME reflex
 )
 
-add_executable(reflex "")
-target_sources(reflex PRIVATE ${bin_sources})
-target_link_libraries(reflex PRIVATE libreflexStatic)
-target_compile_definitions(reflex PRIVATE ${simd_definitions})
-target_compile_options(reflex PRIVATE ${simd_flags})
+#
+# Exporting targets section
+#
 
 include(GNUInstallDirs)
 
-install(TARGETS reflex libreflex libreflexStatic EXPORT reflex
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+install(TARGETS Reflex ReflexLib ReflexLibStatic
+  EXPORT ReflexTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/reflex
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    FILES_MATCHING PATTERN "*.h"
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.h"
 )
 
-install(FILES ${CMAKE_CURRENT_LIST_DIR}/cmake/reflex-config.cmake DESTINATION reflex/share/reflex)
+install(EXPORT ReflexTargets
+  NAMESPACE Reflex::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflex
+)
 
-install(EXPORT reflex DESTINATION reflex/share/reflex)
+#
+# Packaging section (find_package support)
+#
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/ReflexConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflex
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/ReflexConfig.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflex
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ set(bin_sources
 )
 
 set(headers
-  ${CMAKE_CURRENT_LIST_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include
 )
 
-list(TRANSFORM lib_sources PREPEND ${CMAKE_CURRENT_LIST_DIR}/)
-list(TRANSFORM bin_sources PREPEND ${CMAKE_CURRENT_LIST_DIR}/)
+list(TRANSFORM lib_sources PREPEND ${PROJECT_SOURCE_DIR}/)
+list(TRANSFORM bin_sources PREPEND ${PROJECT_SOURCE_DIR}/)
 
 add_library(libreflex SHARED "")
 target_sources(libreflex PRIVATE ${lib_sources})
@@ -51,10 +51,28 @@ target_compile_definitions(libreflexStatic PRIVATE ${simd_definitions})
 target_compile_options(libreflexStatic PRIVATE ${simd_flags})
 
 # Renaming static lib output to match the name (without the extention) of the shared library
-set_target_properties(libreflexStatic PROPERTIES OUTPUT_NAME libreflex)
+set_target_properties(libreflexStatic
+    PROPERTIES OUTPUT_NAME reflex
+)
+set_target_properties(libreflex
+    PROPERTIES OUTPUT_NAME reflex
+)
+
 
 add_executable(reflex "")
 target_sources(reflex PRIVATE ${bin_sources})
 target_link_libraries(reflex PRIVATE libreflexStatic)
 target_compile_definitions(reflex PRIVATE ${simd_definitions})
 target_compile_options(reflex PRIVATE ${simd_flags})
+
+include(GNUInstallDirs)
+
+install(TARGETS reflex libreflex libreflexStatic
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(DIRECTORY include/reflex
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,78 @@ library in `/usr/local/lib` and the `reflex` command in `/usr/local/bin`:
 
     $ sudo sh allinstall.sh
 
-### Configure and make
+### Configure and make - CMake
+
+Configuring the build is done in a separate directory like so:
+
+    $ mkdir build && cd build && cmake ..
+
+Adding options to the configuration step can be done via the -D option when configuring the build.
+The following configuration option `CMAKE_INSTALL_PREFIX` will set the install prefix to a custom
+location:
+
+    $ mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=<path/to/install/dir> ..
+
+To see more configuration options the following the follow command in the build directory:
+
+    $ cmake -LAH ..
+
+To run the main build target the following command can be issued in the build directory:
+
+    $ cmake --build .
+
+To build a specific target, the `--target` option can be used together `--build`.
+
+The following command will install the binary, and libraries in the path specified by 
+`CMAKE_INSTALL_PREFIX`:
+
+    $ cmake --build --target install .
+
+By default, this will place the build artifacts in system accessible path (On Linux /usr/local/,
+Windows C:\Program Files\ ) and may therefore require admin permissions to be executed.
+
+#### Using the reflex in your own CMake supported project as a package
+
+When installed on the system, the `find_package` CMake can be used find the reflex libraries and
+binary, in your own CMake supported project. To do this, add the following line in your CMakeLists.txt
+file:
+
+    find_package(Reflex)
+
+This adds the following targets to your CMakeLists.txt file:
+
+- `Reflex::Reflex` The reflex binary that can be used to generate parser and lexers.
+- `Reflex::ReflexLib` The reflex shared library, that can be used in `target_link_libraries` statements
+to link your targets with the reflex implementation.
+- `Reflex::ReflexLibStatic` The reflex static library, can be used in the same way as the shared
+library target.
+
+Linking against any of the library targets also makes header files available for the targets linking
+against library targets.
+
+#### Using CMake to generate the lexer/parser source files
+
+Following snippet can be used to setup lexer/parser generation using the reflex binary available from 
+the `Reflex:Reflex` target imported with the `find_package` command:
+
+```
+add_custom_command(
+    OUTPUT lex.yy.cpp
+    COMMAND Reflex::Reflex -+ ${CMAKE_CURRENT_SOURCE_DIR}/lexerDefine.l
+    DEPENDS Reflex::Reflex
+    COMMENT "Generating lexer from 'lexerDefine.l'..."
+    VERBATIM
+)
+```
+Here we generate the `lex.yy.cpp` source file from a lexer file located in `CMAKE_CURRENT_SOURCE_DIR`
+directory (which usually is the same directory path that the CMakeLists.txt file is located in).
+Using the `lex.yy.cpp` file as a source file in any of the `target_sources`, `add_executable` or
+`add_library` statements will then trigger this command and generate the `lex.yy.cpp` file.
+
+Any command line arguments that the reflex binary take can be added the `COMMAND` line after the
+`Reflex:Reflex` name.
+
+### Configure and make - Autotools
 
 The configure script accepts configuration and installation options.  To view
 these options, run:

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/ReflexTargets.cmake")
+
+check_required_components(Reflex)

--- a/cmake/SIMDTestAndSetup.cmake
+++ b/cmake/SIMDTestAndSetup.cmake
@@ -1,0 +1,83 @@
+# SIMD intrinsics setup and test.
+# Tests whether specifics intrinsics are available and then defines macro definitions
+# Expose the simd_definitions and simd_flags when included from another cmake file.
+
+include(CheckCXXSourceRuns)
+
+check_cxx_source_runs("
+  #include <immintrin.h>
+  int main() {
+    __m512 n = _mm512_set1_epi8(42);
+    (void)_mm512_cmpeq_epi8_mask(n, n);
+    return 0;
+  }
+" HAVE_AVX512BW)
+
+check_cxx_source_runs("
+  #include <immintrin.h>
+  int main() {
+    __m256i n = _mm256_set1_epi8(42);
+    (void)_mm256_movemask_epi8(_mm256_and_si256(n, n));
+    return 0;
+  }
+" HAVE_AVX2)
+
+check_cxx_source_runs("
+  #include <emmintrin.h>
+  int main() {
+    __m128i n = _mm_set1_epi8(42);
+    return 0;
+  }
+" HAVE_SSE2)
+
+check_cxx_source_runs("
+  #include <arm_neon.h>
+  int main() {
+    uint64x2_t n;
+    uint64_t m = vgetq_lane_u64(n, 0);
+    return 0;
+  }
+" HAVE_NEON)
+
+set(simd_definitions "")
+set(simd_flags "")
+
+if (${HAVE_AVX512BW})
+  list(APPEND simd_definitions HAVE_AVX512BW)
+  if (WIN32 AND MSVC)
+    list(APPEND simd_flags "/arch:AVX512")
+  else()
+    list(APPEND simd_flags "-mavx512bw")
+  endif()
+endif()
+
+if (${HAVE_AVX2})
+  list(APPEND simd_definitions HAVE_AVX2)
+  if (WIN32 AND MSVC)
+    list(APPEND simd_flags "/arch:AVX2")
+  else()
+    list(APPEND simd_flags "-mavx2")
+  endif()
+endif()
+
+if (${HAVE_SSE2})
+  list(APPEND simd_definitions HAVE_SSE2)
+  if (WIN32 AND MSVC)
+    if ("${CMAKE_GENERATOR_PLATFORM}" MATCHES "Win32")
+      # SSE2 is a given if the system is running x64
+      list(APPEND simd_flags "/arch:SSE2")
+    endif()
+  else()
+    list(APPEND simd_flags "-msse2")
+  endif()
+endif()
+
+if (${HAVE_NEON})
+  list(APPEND simd_definitions HAVE_NEON)
+  if (WIN32 AND MSVC)
+    # MSVC runs NEON by default according to their docs
+  else()
+    list(APPEND simd_flags "-march=native" "-mfpu=neon")
+  endif()
+endif()
+

--- a/cmake/SIMDTestAndSetup.cmake
+++ b/cmake/SIMDTestAndSetup.cmake
@@ -4,40 +4,53 @@
 
 include(CheckCXXSourceRuns)
 
-check_cxx_source_runs("
-  #include <immintrin.h>
-  int main() {
-    __m512 n = _mm512_set1_epi8(42);
-    (void)_mm512_cmpeq_epi8_mask(n, n);
-    return 0;
-  }
-" HAVE_AVX512BW)
+option(USE_AVX512BW "Enable AVX512BW intrinsics (if available)" ON)
+option(USE_AVX2 "Enable AVX2 intrinsics (if available)" ON)
+option(USE_SSE2 "Enable SSE2 intrinsics (if available)" ON)
+option(USE_NEON "Enable NEON intrinsics (if available)" ON)
 
-check_cxx_source_runs("
-  #include <immintrin.h>
-  int main() {
-    __m256i n = _mm256_set1_epi8(42);
-    (void)_mm256_movemask_epi8(_mm256_and_si256(n, n));
-    return 0;
-  }
-" HAVE_AVX2)
+if (USE_AVX512BW)
+  check_cxx_source_runs("
+    #include <immintrin.h>
+    int main() {
+      __m512 n = _mm512_set1_epi8(42);
+      (void)_mm512_cmpeq_epi8_mask(n, n);
+      return 0;
+    }
+  " HAVE_AVX512BW)
+endif()
 
-check_cxx_source_runs("
-  #include <emmintrin.h>
-  int main() {
-    __m128i n = _mm_set1_epi8(42);
-    return 0;
-  }
-" HAVE_SSE2)
+if (USE_AVX2)
+  check_cxx_source_runs("
+    #include <immintrin.h>
+    int main() {
+      __m256i n = _mm256_set1_epi8(42);
+      (void)_mm256_movemask_epi8(_mm256_and_si256(n, n));
+      return 0;
+    }
+  " HAVE_AVX2)
+endif()
 
-check_cxx_source_runs("
-  #include <arm_neon.h>
-  int main() {
-    uint64x2_t n;
-    uint64_t m = vgetq_lane_u64(n, 0);
-    return 0;
-  }
-" HAVE_NEON)
+if (USE_SSE2)
+  check_cxx_source_runs("
+    #include <emmintrin.h>
+    int main() {
+      __m128i n = _mm_set1_epi8(42);
+      return 0;
+    }
+  " HAVE_SSE2)
+endif()
+
+if (USE_NEON)
+  check_cxx_source_runs("
+    #include <arm_neon.h>
+    int main() {
+      uint64x2_t n;
+      uint64_t m = vgetq_lane_u64(n, 0);
+      return 0;
+    }
+  " HAVE_NEON)
+endif()
 
 set(simd_definitions "")
 set(simd_flags "")

--- a/cmake/reflex-config.cmake
+++ b/cmake/reflex-config.cmake
@@ -1,0 +1,2 @@
+get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(${SELF_DIR}/reflex.cmake)

--- a/cmake/reflex-config.cmake
+++ b/cmake/reflex-config.cmake
@@ -1,2 +1,0 @@
-get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-include(${SELF_DIR}/reflex.cmake)


### PR DESCRIPTION
I propose CMake support for building and using RE-flex in a cross-platform manner.

This solution adds find_package support for use in other CMake driven projects, as well as some rudimentary documentation showing how to configure and build the RE-flex binary and libraries using the CMake command line interface.

The solution has been tested on:
Windows using the Visual C++ compiler and it's accompanying tools.
Debian Linux 11 using GCC and GnuMakefile.