### PR TITLE
Added virtual destructors to Handler classes.

### DIFF
--- a/include/reflex/absmatcher.h
+++ b/include/reflex/absmatcher.h
@@ -130,7 +130,10 @@ class AbstractMatcher {
     size_t      num; ///< number of bytes shifted out so far, when buffer shifted
   };
   /// Event handler functor base class to invoke when the buffer contents are shifted out, e.g. for logging the data searched.
-  struct Handler { virtual void operator()(AbstractMatcher&, const char*, size_t, size_t) = 0; };
+  struct Handler {
+      virtual void operator()(AbstractMatcher&, const char*, size_t, size_t) = 0;
+      virtual ~Handler() {};
+  };
  protected:
   /// AbstractMatcher::Options for matcher engines.
   struct Option {

--- a/include/reflex/input.h
+++ b/include/reflex/input.h
@@ -316,7 +316,10 @@ class Input {
     static const file_encoding_type custom     = 38; ///< custom code page
   };
   /// FILE* handler functor base class to handle FILE* errors and non-blocking FILE* reads
-  struct Handler { virtual int operator()() = 0; };
+  struct Handler {
+      virtual int operator()() = 0;
+      virtual ~Handler() {};
+  };
   /// Stream buffer for reflex::Input, derived from std::streambuf.
   class streambuf;
   /// Stream buffer for reflex::Input to read DOS files, replaces CRLF by LF, derived from std::streambuf.


### PR DESCRIPTION
If any member function of a class is labeled virtual, dynamic typing is
enabled for this class. All such classes should have virtual
destructors. The g++ option -Wnon-virtual-dtor gives a hint, if a
virtual destructor is missing for a class.