### PR TITLE
Fixed erroneous pre-increment to post-increment.

### DIFF
--- a/include/reflex/absmatcher.h
+++ b/include/reflex/absmatcher.h
@@ -1028,7 +1028,7 @@ class AbstractMatcher {
       return EOF;
     if (static_cast<unsigned char>(*s++ = c) >= 0x80)
     {
-      while (((++*s = get()) & 0xC0) == 0x80)
+      while (((*s++ = get()) & 0xC0) == 0x80)
         continue;
       got_ = static_cast<unsigned char>(buf_[cur_ = --pos_]);
     }


### PR DESCRIPTION
Previous pre-increment in absmatcher.h:1031 was actually causing the value to get incremented rather than the pointer. Also, pre-incrementing the pointer in absmatcher.h:1031 would not work as it is post-incremented in absmatcher.h:1029.

Sample test case:
```
	#include <cassert>
%o unicode
%%
. assert(matcher().winput() == int(U'§')); return 0;
%%
int main() {
	Lexer(u8"0§").lex();
}
```