### PR TITLE
Fixed handling of negatives in UCS4 to UTF8 conversion.

### DIFF
--- a/include/reflex/utf8.h
+++ b/include/reflex/utf8.h
@@ -77,6 +77,12 @@ inline size_t utf8(
     char *s) ///< points to the buffer to populate with UTF-8 (1 to 6 bytes) not NUL-terminated
   /// @returns length (in bytes) of UTF-8 character sequence stored in s
 {
+  if (c < 0)
+  {
+    static const size_t n = sizeof(REFLEX_NONCHAR_UTF8) - 1;
+    std::memcpy(s, REFLEX_NONCHAR_UTF8, n);
+    return n;
+  }
   if (c < 0x80)
   {
     *s++ = static_cast<char>(c);


### PR DESCRIPTION
Converting a negative integer (accidentally) using `int utf8(int, char*)` defined in `utf8.h` was causing it to silently fill a value between 0-255. This can cause `wunput(EOF)` and `skip(EOF)` to return successfully, but actually do something differently than what was intended (fails silently).

I have changed it to fill with `REFLEX_NONCHAR` instead since that was what the code was doing for out-of-range codepoints.

You may even decide to throw instead.