### PR TITLE
yyrestart: fix first FILE* character getting swallwed

### DIFF
--- a/include/reflex/abslexer.h
+++ b/include/reflex/abslexer.h
@@ -130,7 +130,7 @@ class AbstractLexer {
   {
     in_ = input;
     if (has_matcher())
-      matcher().input(input); // reset and assign new input
+      matcher().input(in_); // reset and assign new input
     return *this;
   }
   /// Reset the matcher and start scanning from the given byte sequence.


### PR DESCRIPTION
The Input constructor was being called twice, thereby twice reading the "first" character to check for an UTF signature and only caching the second one for use during parsing.

resolves #178