### PR TITLE
Prevent class redefinitions by not generating lexer class in cpp file if generating a header file.

### DIFF
--- a/src/reflex.cpp
+++ b/src/reflex.cpp
@@ -1757,7 +1757,8 @@ void Reflex::write()
     options["lexer"] = options["prefix"] + (!options["flex"].empty() ? "FlexLexer" : "Lexer");
   if (options["lex"].empty())
     options["lex"] = options["prefix"] + "lex";
-  if (options["header_file"] == "true")
+  bool createHeader = (options["header_file"] == "true");
+  if (createHeader)
   {
     if (options["prefix"].empty())
       options["header_file"] = "lex.yy.h";
@@ -1807,7 +1808,20 @@ void Reflex::write()
   write_prelude();
   write_section_top();
   write_defines();
-  write_class();
+
+  // don't create a class definition in the cpp, just include the header
+  if(createHeader)
+  {
+    write_banner("LEXER CLASS INCLUDE");
+    *out << 
+    "#include " << "\"" << options["header_file"] << "\"" <<'\n';
+  }
+  else
+  {
+    // write the class in the cpp file, now that there isn't a header being created.
+    write_class();
+  }
+
   write_section_1();
   write_lexer();
   write_main();


### PR DESCRIPTION
Class redefinition can be introduced in the lexer cpp by including the class again in the user code section. This pr provides logic to fix redefinition by not generating the lexer class in cpp, but instead by including the generated header file.

Attached is some code that does redefinition, with the include fix and non include breaking code.
[Debug.zip](https://github.com/Genivia/RE-flex/files/11639658/Debug.zip)
