### PR TITLE
Ignore -march=native for arm64 architecture

### DIFF
--- a/cmake/SIMDTestAndSetup.cmake
+++ b/cmake/SIMDTestAndSetup.cmake
@@ -87,8 +87,8 @@ endif()
 
 if (${HAVE_NEON})
   list(APPEND simd_definitions HAVE_NEON)
-  if (WIN32 AND MSVC)
-    # MSVC runs NEON by default according to their docs
+  if ((${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64|aarch64") OR (WIN32 AND MSVC))
+    # Arm64 compilers and MSVC runs NEON by default according to their docs
   else()
     list(APPEND simd_flags "-march=native" "-mfpu=neon")
   endif()


### PR DESCRIPTION
Flag "-march=native" leads to errors on arm CPU and new compilers, at least clang-15 and above. Without the flag it works on clang 14, 15 and 17. Checked on MacOS with M1 CPU and Linux aarch64. To be honest I cannot find official documentation which mentions it enabled by default but many people say about that in the internet, so I'm not sure about the comment message.

Please let me know if something in the commit is not right.