### PR TITLE
Add missing headers

### DIFF
--- a/examples/gz.l
+++ b/examples/gz.l
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <streambuf>
 #include <cstring>
+#include <unistd.h>
 #include <zlib.h>
 
 #ifndef Z_BUF_LEN

--- a/examples/lua.hpp
+++ b/examples/lua.hpp
@@ -7,6 +7,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
+#include <memory>
 #include <string>
 #include <set>
 #include <stack>

--- a/examples/minic.hpp
+++ b/examples/minic.hpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <map>
 #include <set>


### PR DESCRIPTION
- dup() is defined in unistd.h
- strcmp() is defined in cstring
- std::unique_ptr<> is defined in memory

These cause compilation errors on NetBSD 10 using clang(++).