### PR TITLE
Add CMake support for generating Reflex targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in
 )
 
 install(FILES
+  cmake/ReflexCMakeSupport.cmake
   "${CMAKE_CURRENT_BINARY_DIR}/ReflexConfig.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflex
 )

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -3,3 +3,4 @@
 include("${CMAKE_CURRENT_LIST_DIR}/ReflexTargets.cmake")
 
 check_required_components(Reflex)
+include("${CMAKE_CURRENT_LIST_DIR}/ReflexCMakeSupport.cmake")

--- a/cmake/ReflexCMakeSupport.cmake
+++ b/cmake/ReflexCMakeSupport.cmake
@@ -1,0 +1,55 @@
+if (NOT TARGET Reflex::Reflex)
+    message(FATAL_ERROR "Reflex::Reflex is not a target, please make sure Reflex executable is a target before including this script")
+endif()
+
+function(reflex_target_sources_headers)
+    set(REFLEX_OPTIONS "REFLEXLIB_STATIC")
+    set(REFLEX_SINGLE_VALUE_KEYWORDS "TARGET" "INCLUDE_PRIVACY")
+    set(REFLEX_MULTIVALUE_KEYWORDS "SOURCES")
+
+    cmake_parse_arguments("" "${REFLEX_OPTIONS}" "${REFLEX_SINGLE_VALUE_KEYWORDS}" "${REFLEX_MULTIVALUE_KEYWORDS}" "${ARGV}")
+    message(STATUS "_SOURCES=${_SOURCES}")
+    list(LENGTH _SOURCES sources_count)
+    if (sources_count LESS 1)
+        message(FATAL_ERROR "No input files specified for Reflex")
+    endif()
+
+    set(processed_filepaths)
+    set(output_sources)
+    set(output_headers)
+    set(source_output_prefix ${CMAKE_CURRENT_BINARY_DIR}/reflex_generated_${_TARGET})
+
+    file(MAKE_DIRECTORY ${source_output_prefix})
+    set(header_output_prefix ${source_output_prefix}/include/${_TARGET})
+    file(MAKE_DIRECTORY ${header_output_prefix})
+
+    foreach(filepath IN LISTS _SOURCES)
+        cmake_path(IS_ABSOLUTE filepath is_filepath_absolute)
+        if (NOT is_filepath_absolute)
+            set(filepath ${CMAKE_CURRENT_SOURCE_DIR}/${filepath})
+        endif()
+        list(APPEND processed_filepaths ${filepath})
+
+        get_filename_component(filename_we ${filepath} NAME_WE)
+        list(APPEND output_sources ${source_output_prefix}/${filename_we}.cpp)
+        list(APPEND output_headers ${header_output_prefix}/${filename_we}.hpp)
+    endforeach()
+
+    # Call Reflex and properly specify dependencies and outputs for CMake to track properly
+    foreach(filename IN ZIP_LISTS processed_filepaths output_sources output_headers)
+        add_custom_command(
+            OUTPUT ${filename_1}
+            COMMAND $<TARGET_FILE:Reflex::Reflex> ${filename_0} -o ${filename_1} --header-file=${filename_2}
+            DEPENDS ${filename_0}
+        )
+    endforeach()
+
+    target_sources(${_TARGET} PRIVATE ${output_sources})
+    target_include_directories(${_TARGET} ${_INCLUDE_PRIVACY} ${source_output_prefix}/include)
+
+    if (_REFLEXLIB_STATIC)
+        target_link_libraries(${_TARGET} PRIVATE Reflex::ReflexLibStatic)
+    else()
+        target_link_libraries(${_TARGET} PRIVATE Reflex::ReflexLib)
+    endif()
+endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.15)
+project(reflex-examples CXX)
+
+find_package(Reflex REQUIRED)
+
+add_executable(echo)
+reflex_target_sources_headers(
+    TARGET echo
+    SOURCES echo.l
+    INCLUDE_PRIVACY PRIVATE
+)
+
+add_executable(calc)
+reflex_target_sources_headers(
+    TARGET calc
+    SOURCES calc.l
+    INCLUDE_PRIVACY PRIVATE
+)


### PR DESCRIPTION


This PR addresses #203, adds a cmake function to create Reflex targets from the specified sources. It aims to provide easy-to-use CMake interface for users wishing to use Reflex as lexer generator. The product of the function is self-sufficient target. In case of a library the users can freely `target_link_libraries` against it.

The signature of the function is straightforward:

```cmake
add_reflex_target(
    TARGET_TYPE <EXECUTABLE|LIBRARY>
    TARGET <target_name>
    LIBRARY_TYPE <whataever add_library accepts as type>
    FILES <list of reflex source files>
    INCLUDE_DIRECTORIES <list of public include directories>
    DEPENDENCY_TARGETS <list of targets to put inside target_link_libraries(<target_name> PUBLIC )>
)
```