### PR TITLE
MinGW-w64 build: fix undefined reference to reflex::Unicode::Tables::composer()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(lib_sources
   unicode/block_scripts.cpp
   unicode/language_scripts.cpp
   unicode/letter_scripts.cpp
+  unicode/letter_case.cpp
   unicode/composer.cpp
 )
 


### PR DESCRIPTION
…Tables::toupper(int)'

When building version 5.3.0 for Windows with MinGW-w64 the following error appears:
```raw
[40/41] Linking CXX executable reflex.exe
FAILED: reflex.exe
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\Prog\winlibs14.2.0msvcrt\mingw64\bin\c++.exe -O3
-DNDEBUG  CMakeFiles/Reflex.dir/src/reflex.cpp.obj -o reflex.exe -Wl,--out-implib,libreflex.dll.a -Wl,--major-image-version,0,--minor-image-version,0  libreflex.a  -lkernel32 -luser32
-lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
C:/Prog/winlibs14.2.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libreflex.a(unicode.cpp.obj):unicode.cpp:(.text+0x7c8): undefined reference to `reflex::Unicode::Tables::toupper(int)'
C:/Prog/winlibs14.2.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libreflex.a(unicode.cpp.obj):unicode.cpp:(.text+0x7a1): undefined reference to `reflex::Unicode::Tables::toupper(int)'
C:/Prog/winlibs14.2.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libreflex.a(unicode.cpp.obj):unicode.cpp:(.text+0x7b1): undefined reference to `reflex::Unicode::Tables::tolower(int)'
C:/Prog/winlibs14.2.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libreflex.a(unicode.cpp.obj):unicode.cpp:(.text+0x7e8): undefined reference to `reflex::Unicode::Tables::tolower(int)'
collect2.exe: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

This is fixed by adding `unicode/letter_case.cpp` to the sources in `CMakeLists.txt`