### PR TITLE
Fix all warnings on Linux

### DIFF
--- a/include/reflex/absmatcher.h
+++ b/include/reflex/absmatcher.h
@@ -583,7 +583,6 @@ class AbstractMatcher {
     }
     return *this;
   }
-  
   /// Returns nonzero capture index (i.e. true) if the entire input matches this matcher's pattern (and internally caches the true/false result to permit repeat invocations).
   inline size_t matches()
     /// @returns nonzero capture index if the entire input matched this matcher's pattern, zero (i.e. false) otherwise
@@ -1691,7 +1690,7 @@ class PatternMatcher : public AbstractMatcher {
       delete pat_;
   }
   /// Assign a matcher, the underlying pattern object is shared (not deep copied).
-  virtual PatternMatcher& operator=(const PatternMatcher& matcher) ///< matcher with pattern to use (pattern may be shared)
+  PatternMatcher& operator=(const PatternMatcher& matcher) ///< matcher with pattern to use (pattern may be shared)
   {
     scan.init(this, Const::SCAN);
     find.init(this, Const::FIND);
@@ -1842,7 +1841,7 @@ class PatternMatcher<std::string> : public AbstractMatcher {
       delete pat_;
   }
   /// Assign a matcher, the underlying pattern string is shared (not deep copied).
-  virtual PatternMatcher& operator=(const PatternMatcher& matcher) ///< matcher with pattern to use (pattern may be shared)
+  PatternMatcher& operator=(const PatternMatcher& matcher) ///< matcher with pattern to use (pattern may be shared)
   {
     scan.init(this, Const::SCAN);
     find.init(this, Const::FIND);

--- a/include/reflex/matcher.h
+++ b/include/reflex/matcher.h
@@ -109,7 +109,7 @@ class Matcher : public PatternMatcher<reflex::Pattern> {
   }
   using PatternMatcher::operator=;
   /// Assign a matcher, the underlying pattern string is shared (not deep copied).
-  virtual Matcher& operator=(const Matcher& matcher) ///< matcher to copy
+  Matcher& operator=(const Matcher& matcher) ///< matcher to copy
   {
     PatternMatcher<reflex::Pattern>::operator=(matcher);
     ded_ = matcher.ded_;


### PR DESCRIPTION
## Problem

I got these warnings when compiling re-flex on Linux (gcc-14.2.1).

```
make[2]: Entering directory '/home/hungptit/working/ioutils/.local/build/reflex/tests'
g++ -DHAVE_CONFIG_H -I. -I/home/hungptit/working/ioutils/_deps/reflex-src/tests -I..  -I/home/hungptit/working/ioutils/_deps/reflex-src/include   -Wall -Wextra -Wunused -O2 -MT rtest-rtest.o -MD -MP -MF .deps/rtes
t-rtest.Tpo -c -o rtest-rtest.o `test -f 'rtest.cpp' || echo '/home/hungptit/working/ioutils/_deps/reflex-src/tests/'`rtest.cpp
In file included from /home/hungptit/working/ioutils/_deps/reflex-src/tests/rtest.cpp:7:
/home/hungptit/working/ioutils/_deps/reflex-src/include/reflex/matcher.h:112:20: warning: ‘virtual reflex::Matcher& reflex::Matcher::operator=(const reflex::Matcher&)’ was hidden [-Woverloaded-virtual=]
  112 |   virtual Matcher& operator=(const Matcher& matcher) ///< matcher to copy
      |                    ^~~~~~~~               
/home/hungptit/working/ioutils/_deps/reflex-src/tests/rtest.cpp:31:7: note:   by ‘WrappedMatcher::operator=’
   31 | class WrappedMatcher : public Matcher {                                                                                                                                                                      
      |       ^~~~~~~~~~~~~~                                                                              
In file included from /home/hungptit/working/ioutils/_deps/reflex-src/include/reflex/matcher.h:40:                                                                                                                   
/home/hungptit/working/ioutils/_deps/reflex-src/include/reflex/absmatcher.h:1694:27: warning: ‘reflex::PatternMatcher<P>& reflex::PatternMatcher<P>::operator=(const reflex::PatternMatcher<P>&) [with P = reflex::Pa
ttern]’ was hidden [-Woverloaded-virtual=]                                                                
 1694 |   virtual PatternMatcher& operator=(const PatternMatcher& matcher) ///< matcher with pattern to use (pattern may be shared)
      |                           ^~~~~~~~                                                                
/home/hungptit/working/ioutils/_deps/reflex-src/tests/rtest.cpp:31:7: note:   by ‘WrappedMatcher::operator=’
   31 | class WrappedMatcher : public Matcher {                                                           
      |       ^~~~~~~~~~~~~~                                                   
```

## Solution

Remove the virtual keywords in related template classes.