### PR TITLE
Fix compile error on windows using mingw

### DIFF
--- a/lib/input.cpp
+++ b/lib/input.cpp
@@ -39,7 +39,13 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__)
+# define REFLEX_WINDOWS_FILE_IO 1
+#else
+# define REFLEX_WINDOWS_FILE_IO 0
+#endif
+
+#if REFLEX_WINDOWS_FILE_IO
 # include <io.h>
 # include <fcntl.h>
 # define off_t __int64
@@ -47,11 +53,7 @@
 # define fseeko _fseeki64
 #else
 # include <unistd.h> // off_t, fstat()
-# if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64)) && (defined(__MINGW32__) || defined(__MINGW64__)) && defined(_UCRT)
-#  include <winsock2.h>
-# else
-#  include <sys/select.h>
-# endif
+# include <sys/select.h>
 #endif
 
 namespace reflex {
@@ -653,7 +655,7 @@ void Input::file_init()
 {
   // attempt to determine the file size with fstat()
 #if !defined(HAVE_CONFIG_H) || defined(HAVE_FSTAT)
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if REFLEX_WINDOWS_FILE_IO
   struct _stat st;
   if (_fstat(_fileno(file_), &st) == 0 && ((st.st_mode & S_IFMT) == S_IFREG) && st.st_size <= 4294967295LL)
 #else
@@ -1030,7 +1032,7 @@ bool Input::file_ready()
 {
   if (file_ == NULL || feof(file_))
     return false;
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#if REFLEX_WINDOWS_FILE_IO
   return !ferror(file_);
 #else
   int fd = fileno(file_);


### PR DESCRIPTION
Hi, 

I noted that on windows I get the following compile error:

```
"D:\a\_temp\msys64\mingw64\bin/ccache.EXE" "g++" "-Isubprojects/RE-flex-6.3.0/libreflex_static_lib.a.p" "-Isubprojects/RE-flex-6.3.0" "-I../subprojects/RE-flex-6.3.0" "-I../subprojects/RE-flex-6.3.0/include" "-fdiagnostics-color=always" "-DNDEBUG" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wextra" "-Wpedantic" "-std=c++11" "-O3" "-g" -MD -MQ subprojects/RE-flex-6.3.0/libreflex_static_lib.a.p/lib_input.cpp.obj -MF "subprojects/RE-flex-6.3.0/libreflex_static_lib.a.p/lib_input.cpp.obj.d" -o subprojects/RE-flex-6.3.0/libreflex_static_lib.a.p/lib_input.cpp.obj "-c" ../subprojects/RE-flex-6.3.0/lib/input.cpp
../subprojects/RE-flex-6.3.0/lib/input.cpp:53:12: fatal error: sys/select.h: No such file or directory
   53 | #  include <sys/select.h>
      |            ^~~~~~~~~~~~~~
compilation terminated.
```

This is because I'm using the mingw compilers, and for some reason they are not treated as windows compilers.  The current PR fixes the issue by treating MINGW just like other windows compilers, which seems like the correct fix.

