### PR TITLE
README Update: my usage of Reflex for a port

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 A high-performance C++ regex library and lexical analyzer generator with
 Unicode support.
 
-Two example use cases:
+Three example use cases:
 
 1. A RE/flex-generated tokenizer is used by the
    [Tiger Compiler](https://assignments.lre.epita.fr/tools/reflex.html).
 2. The RE/flex C++ regex engines are used by [ugrep](https://ugrep.com).
+3. As a build dependency for the GCC 3.3 portion of a [2026 port](https://github.com/BRS-PSP-Research-Initiative/Psptoolchain-Allegrex-3.3) of the open source PSXSDK to GCC 3.3.6, a common version used in the official Sony Playstation Portable development kit.
 
 The RE/flex lexical analyzer generator extends Flex++ with Unicode support,
 indent/dedent anchors, POSIX regex lazy quantifiers, word boundaries, functions

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Three example use cases:
 1. A RE/flex-generated tokenizer is used by the
    [Tiger Compiler](https://assignments.lre.epita.fr/tools/reflex.html).
 2. The RE/flex C++ regex engines are used by [ugrep](https://ugrep.com).
-3. As a build dependency for the GCC 3.3 portion of a [2026 port](https://github.com/BRS-PSP-Research-Initiative/Psptoolchain-Allegrex-3.3) of the open source PSXSDK to GCC 3.3.6, a common version used in the official Sony Playstation Portable development kit.
+3. As a build dependency for the GCC 3.3 portion of a [2026 port](https://github.com/BRS-PSP-Research-Initiative/Psptoolchain-Allegrex-3.3) of the open source PSPSDK to GCC 3.3.6, a common version used in the official Sony Playstation Portable development kit.
 
 The RE/flex lexical analyzer generator extends Flex++ with Unicode support,
 indent/dedent anchors, POSIX regex lazy quantifiers, word boundaries, functions


### PR DESCRIPTION
Even though my port of PSPDev’s Allegrex toolchain to work with GCC 3.3 (and other common versions Sony’s tools were built upon) is a work in progress, the newest version of ReFlex saved me hours of time that would have been spent porting Flex 5 code to work with Flex 6 due to GCC requiring a very specific patch to build upon. The cross compiler portion is almost finished and the final build is looking very promising despite being very much a prototype at this stage. Thank you